### PR TITLE
Added support for .pdf receipts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,12 @@
 module github.com/indecstty/findl
 
-go 1.12
+go 1.17
 
-require golang.org/x/crypto v0.0.0-20200414173820-0848c9571904
+require (
+	github.com/pdfcpu/pdfcpu v0.4.1 // indirect
+	github.com/sunshineplan/imgconv v1.1.4 // indirect
+	github.com/yourbasic/graph v1.0.1 // indirect
+	github.com/yourbasic/radix v1.1.1 // indirect
+	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519
+	gopkg.in/gographics/imagick.v3 v3.4.2 // indirect
+)


### PR DESCRIPTION
This tool had to be updated as well, because it was allowed to add .pdf receipt files in the Findecs site. Now the tool checks the receipt's filetype and converts it to photo if necessary.